### PR TITLE
Optional cursorword highlighting in insert mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ require('nvim-cursorline').setup {
     enable = true,
     min_length = 3,
     hl = { underline = true },
+    insert_highlighting = true,
   }
 }
 ```

--- a/lua/nvim-cursorline.lua
+++ b/lua/nvim-cursorline.lua
@@ -18,6 +18,7 @@ local DEFAULT_OPTIONS = {
     enable = true,
     min_length = 3,
     hl = { underline = true },
+    insert_highlighting = true,
   },
 }
 
@@ -91,11 +92,18 @@ function M.setup(options)
         matchadd()
       end,
     })
-    au({ "CursorMoved", "CursorMovedI" }, {
+    au({ "CursorMoved" }, {
       callback = function()
         matchadd()
       end,
     })
+    if M.options.cursorword.insert_highlighting then
+      au({ "CursorMovedI" }, {
+        callback = function()
+          matchadd()
+        end,
+      })
+    end
   end
 end
 


### PR DESCRIPTION
Cursorword highlighting may not be desired when in insert mode. When cursorword highlighting uses fg and bg options particularly, the highlighting of the current word feels distracting. For example if the user is typing the word "return", highlighting triggers for "ret", "retu", "retur" and finally "return". Attaching example screenshot to ticket.